### PR TITLE
Fix truncated HTML and add animations

### DIFF
--- a/index.html
+++ b/index.html
@@ -201,13 +201,62 @@
 
   <!-- Interactive Scripts -->
   <script>
-    // Accordion functionality
+    // Accordion functionality with fade animation
     document.querySelectorAll('.accordion-header').forEach(header => {
       header.addEventListener('click', () => {
         const body = header.nextElementSibling;
-        body.style.maxHeight = body.style.maxHeight ? null : body.scrollHeight + 'px';
+        if (body.style.maxHeight) {
+          body.style.maxHeight = null;
+          body.classList.remove('open');
+        } else {
+          body.style.maxHeight = body.scrollHeight + 'px';
+          body.classList.add('open');
+        }
         header.classList.toggle('active');
       });
     });
 
     // Book carousel functionality
+    const track = document.querySelector('.carousel-track');
+    const prevBtn = document.querySelector('.carousel-btn.prev');
+    const nextBtn = document.querySelector('.carousel-btn.next');
+    const items = document.querySelectorAll('.carousel-track .book-item');
+    let index = 0;
+
+    function updateCarousel() {
+      const itemWidth = items[0].offsetWidth + 16; // 16px gap
+      track.style.transform = `translateX(${-index * itemWidth}px)`;
+    }
+
+    nextBtn.addEventListener('click', () => {
+      if (index < items.length - 1) {
+        index++;
+        updateCarousel();
+      }
+    });
+
+    prevBtn.addEventListener('click', () => {
+      if (index > 0) {
+        index--;
+        updateCarousel();
+      }
+    });
+
+    window.addEventListener('resize', updateCarousel);
+
+    // Fade-in animations for images and media
+    const observer = new IntersectionObserver(entries => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('visible', 'appear');
+          observer.unobserve(entry.target);
+        }
+      });
+    }, { threshold: 0.3 });
+
+    document.querySelectorAll('.book-item img, #media .accordion-item').forEach(el => {
+      observer.observe(el);
+    });
+  </script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -111,14 +111,6 @@ body {
 .accordion-header.active::after {
   content: '-';
 }
-.accordion-body {
-  max-height: 0;
-  overflow: hidden;
-  transition: max-height 0.3s ease;
-  background: #fafafa;
-  padding: 0 1rem;
-  border-radius: 0 0 4px 4px;
-}
 .accordion-body ul {
   margin: 1rem 0;
   list-style: disc;
@@ -216,4 +208,44 @@ body {
   text-align: center;
   margin: 3rem 0;
   color: #666;
+}
+
+/* Animations */
+@keyframes fadeInUp {
+  from { opacity: 0; transform: translateY(20px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.accordion-body {
+  max-height: 0;
+  overflow: hidden;
+  opacity: 0;
+  transition: max-height 0.3s ease, opacity 0.3s ease;
+  background: #fafafa;
+  padding: 0 1rem;
+  border-radius: 0 0 4px 4px;
+}
+
+.accordion-body.open {
+  opacity: 1;
+}
+
+.media .accordion-item {
+  opacity: 0;
+  transform: translateY(20px);
+}
+
+.media .accordion-item.appear {
+  animation: fadeInUp 0.6s forwards;
+}
+
+.book-item img {
+  opacity: 0;
+  transform: scale(0.95);
+  transition: opacity 0.6s ease, transform 0.6s ease;
+}
+
+.book-item img.visible {
+  opacity: 1;
+  transform: scale(1);
 }


### PR DESCRIPTION
## Summary
- restore closing HTML and JS for the carousel
- enhance accordion behavior with fade animations
- animate book images and media items as they appear

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887109af3448331b9d43208efacece7