### PR TITLE
Restore interactive media section

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
         <li><a href="#experience">Experience</a></li>
         <li><a href="#portfolio">Portfolio</a></li>
         <li><a href="#publications">Books</a></li>
+        <li><a href="#media">Media</a></li>
         <li><a href="#contact">Contact</a></li>
       </ul>
     </nav>
@@ -150,6 +151,125 @@
     <p class="center-btn"><a href="https://www.amazon.com/stores/Jordan-Charles-Lander/author/B0C5TYWMDD" target="_blank" class="btn">Shop My Books</a></p>
   </section>
 
+  <!-- Media Mentions Section -->
+  <section id="media" class="section media">
+    <h2>Jordan Lander in the Headlines</h2>
+    <div class="accordion" id="mediaAccordion">
+      <div class="accordion-item">
+        <button class="accordion-header">School board talks budget, updates, eliminating policy (Apr 28 2023)</button>
+        <div class="accordion-body">
+          <p>As part of a dynamic leadership team, Jordan helped drive a blockbuster book fair that raised $16K+, powering new learning resources and deepening community partnerships.</p>
+          <p><a href="https://www.thecorryjournal.com/news/school-board-talks-budget-updates-eliminating-policy/article_6745a866-e599-11ed-8665-470b4e35134c.html" target="_blank">Read Article</a></p>
+        </div>
+      </div>
+      <div class="accordion-item">
+        <button class="accordion-header">School board approves audit, hears security update (Nov 15 2022)</button>
+        <div class="accordion-body">
+          <p>Collaborating with district administrators, Jordan provided strategic insights on campus safety and compliance at Corry Area Intermediate School.</p>
+          <p><a href="https://www.thecorryjournal.com/news/school-board-approves-audit-hears-security-update/article_1a41c98a-6507-11ed-a7c7-d7dfce34ed02.html" target="_blank">Read Article</a></p>
+        </div>
+      </div>
+      <div class="accordion-item">
+        <button class="accordion-header">Round of a PAWS (Dec 23 2022)</button>
+        <div class="accordion-body">
+          <p>Partnering with teachers and student leaders, Jordan co-led the “PAWS” recognition program, celebrating hundreds of student achievements.</p>
+          <p><a href="https://www.thecorryjournal.com/news/round-of-a-paws/article_297d955c-824c-11ed-a4e5-1b978a9ad65c.html" target="_blank">Read Article</a></p>
+        </div>
+      </div>
+      <div class="accordion-item">
+        <button class="accordion-header">School achieves fun in summer sun with programming (Jun 30 2023)</button>
+        <div class="accordion-body">
+          <p>Together with the Summer Learning Task Force, Jordan designed hands-on programs that kept students curious and advancing all season.</p>
+          <p><a href="https://www.thecorryjournal.com/news/school-achieves-fun-in-summer-sun-with-programming/article_9b631ada-16f5-11ee-b226-6b37c0ab098e.html" target="_blank">Read Article</a></p>
+        </div>
+      </div>
+      <div class="accordion-item">
+        <button class="accordion-header">Test scores show improvement in math at CASD (Sep 28 2023)</button>
+        <div class="accordion-body">
+          <p>Leading a data-team cohort, Jordan helped pinpoint gaps and launch targeted interventions—driving measurable math gains for diverse learners.</p>
+          <p><a href="https://www.thecorryjournal.com/news/test-scores-show-improvement-in-math-at-casd/article_1c946648-5e2c-11ee-bd1e-5b0797c490f7.html" target="_blank">Read Article</a></p>
+        </div>
+      </div>
+      <div class="accordion-item">
+        <button class="accordion-header">Students honor valor in verse (Nov 8 2023)</button>
+        <div class="accordion-body">
+          <p>Working alongside the social studies department, Jordan organized a Veterans Day poetry tribute that blended service learning with student creativity.</p>
+          <p><a href="https://www.thecorryjournal.com/news/students-honor-valor-in-verse/article_ea0b4548-7dfe-11ee-82b4-634592829f4c.html" target="_blank">Read Article</a></p>
+        </div>
+      </div>
+      <div class="accordion-item">
+        <button class="accordion-header">‘Santa Fund’ campaign underway (Dec 9 2023)</button>
+        <div class="accordion-body">
+          <p>As part of the holiday giving committee, Jordan championed the Santa Fund drive—providing festive support to dozens of local families in need.</p>
+          <p><a href="https://www.thecorryjournal.com/news/santa-fund-campaign-underway/article_e094cd60-96a2-11ee-a86a-d74da3d7b9b4.html" target="_blank">Read Article</a></p>
+        </div>
+      </div>
+      <div class="accordion-item">
+        <button class="accordion-header">Heroes bring early Christmas for Corry, UC kids (Dec 20 2024)</button>
+        <div class="accordion-body">
+          <p>Collaborating with community partners, Jordan helped deliver magical early-Christmas experiences for under-resourced students.</p>
+          <p><a href="https://www.thecorryjournal.com/news/heroes-bring-early-christmas-for-corry-uc-kids/article_f93f91ce-ae74-11ee-b29c-3f9a5df9a446.html" target="_blank">Read Article</a></p>
+        </div>
+      </div>
+      <div class="accordion-item">
+        <button class="accordion-header">CAIS to support city K‑9 initiative (Dec 8 2022)</button>
+        <div class="accordion-body">
+          <p>Working with law-enforcement liaisons, Jordan supported a unique K‑9 initiative—strengthening safety partnerships and student engagement.</p>
+          <p><a href="https://www.thecorryjournal.com/news/cais-to-support-city-k-9-initiative/article_b8821f98-76f4-11ed-a2e1-4f192ce7cbf1.html" target="_blank">Read Article</a></p>
+        </div>
+      </div>
+      <div class="accordion-item">
+        <button class="accordion-header">Acclaimed children’s author David Gorman to visit Corry area schools (Mar 7 2024)</button>
+        <div class="accordion-body">
+          <p>Coordinating with library staff, Jordan curated live author visits that inspired a renewed passion for reading across the district.</p>
+          <p><a href="https://www.thecorryjournal.com/news/acclaimed-childrens-author-david-gorman-to-visit-corry-area-schools/article_1b29a42c-dd12-11ee-b8a5-3f8f3aee845d.html" target="_blank">Read Article</a></p>
+        </div>
+      </div>
+      <div class="accordion-item">
+        <button class="accordion-header">School board approves graduating class ahead of diploma ceremony (May 25 2023)</button>
+        <div class="accordion-body">
+          <p>Partnering with administrators and parent volunteers, Jordan streamlined graduation logistics to ensure a seamless, celebratory senior send-off.</p>
+          <p><a href="https://www.thecorryjournal.com/news/school-board-approves-graduating-class-ahead-of-diploma-ceremony/article_0bda5ff2-fb1e-11ed-82e5-8ffcb7ae9e2b.html" target="_blank">Read Article</a></p>
+        </div>
+      </div>
+      <div class="accordion-item">
+        <button class="accordion-header">CAIS a finalist in ‘How Cool is Your School?’ contest (Nov 1 2022)</button>
+        <div class="accordion-body">
+          <p>Leading a student-driven media team, Jordan guided the production of award-winning project videos—fueling a culture of innovation.</p>
+          <p><a href="https://www.thecorryjournal.com/news/cais-a-finalist-in-how-cool-is-your-school-contest/article_86360e4c-5a5b-11ed-845d-2f6d4a71512d.html" target="_blank">Read Article</a></p>
+        </div>
+      </div>
+      <div class="accordion-item">
+        <button class="accordion-header">Elementary schools invite families to get involved (Oct 14 2022)</button>
+        <div class="accordion-body">
+          <p>Co-designing family engagement strategies, Jordan helped launch Title I reading nights that brought parents, teachers, and students together.</p>
+          <p><a href="https://www.thecorryjournal.com/news/elementary-schools-invite-families-to-get-involved/article_f6aab036-4bb5-11ed-9ef2-e3d61d6e8a9c.html" target="_blank">Read Article</a></p>
+        </div>
+      </div>
+      <div class="accordion-item">
+        <button class="accordion-header">Considering the City: Building a Bayfront Highway (Mar 10 2023)</button>
+        <div class="accordion-body">
+          <p>Showcased a collaborative digital collage &amp; AI illustration in Erie Reader, blending art &amp; civic dialogue around Bayfront planning.</p>
+          <p><a href="https://www.eriereader.com/article/considering-the-city-building-a-bayfront-highway" target="_blank">Read Article</a></p>
+        </div>
+      </div>
+      <div class="accordion-item">
+        <button class="accordion-header">Town Hall Moderator, Connect Urban Erie (Aug 2022)</button>
+        <div class="accordion-body">
+          <p>Moderated the 2022 Connect Urban Erie Town Hall, guiding community conversations on urban design and development.</p>
+          <p><a href="https://www.connecturbanerie.com/" target="_blank">Visit Site</a></p>
+        </div>
+      </div>
+      <div class="accordion-item">
+        <button class="accordion-header">2024 Jan Stauber Literacy Grant Winner</button>
+        <div class="accordion-body">
+          <p>Co‑recipient of the 2024 Jan Stauber Literacy Grant, pioneering Sherlock Holmes–themed reading initiatives alongside school librarians.</p>
+          <p><a href="https://www.beaconsociety.com/past---current-grant-awards.html" target="_blank">Learn More</a></p>
+        </div>
+      </div>
+    </div>
+  </section>
+
   <!-- Contact Section -->
   <section id="contact" class="section contact">
     <h2>Let’s Connect</h2>
@@ -200,6 +320,20 @@
     });
 
     window.addEventListener('resize', updateCarousel);
+
+    // Fade-in animations for images and media
+    const observer = new IntersectionObserver(entries => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('visible', 'appear');
+          observer.unobserve(entry.target);
+        }
+      });
+    }, { threshold: 0.3 });
+
+    document.querySelectorAll('.book-item img, #media .accordion-item').forEach(el => {
+      observer.observe(el);
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- restore the navigation link to Media
- add Media Mentions section with accordion items
- enable fade-in animations for media and images

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887135321448331bdced58c85cfe79d