### PR TITLE
Fix mobile nav and sticky header

### DIFF
--- a/index.html
+++ b/index.html
@@ -296,6 +296,17 @@
       navToggle.innerHTML = navToggle.classList.contains('open') ? '&#10005;' : '&#9776;';
     });
 
+    // Close mobile menu when a link is clicked
+    document.querySelectorAll('.nav-list a').forEach(link => {
+      link.addEventListener('click', () => {
+        if (navList.classList.contains('open')) {
+          navList.classList.remove('open');
+          navToggle.classList.remove('open');
+          navToggle.innerHTML = '&#9776;';
+        }
+      });
+    });
+
     // Accordion functionality
     document.querySelectorAll('.accordion-header').forEach(header => {
       header.addEventListener('click', () => {

--- a/styles.css
+++ b/styles.css
@@ -18,11 +18,15 @@ body {
   background: #0e2a47;
   color: #fff;
   text-align: center;
-  padding: 2rem 1rem;
+  padding: 0 1rem 2rem;
 }
 .nav {
   margin-bottom: 1rem;
-  position: relative;
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  background: #0e2a47;
+  width: 100%;
 }
 .nav-toggle {
   display: none;


### PR DESCRIPTION
## Summary
- keep navigation visible when scrolling by making the nav sticky
- close the hamburger menu when a nav link is selected
- adjust header spacing for sticky nav

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688847add35083318aa70c59045dd3e3