### PR TITLE
Add Leadership Highlights section

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
   <meta name="robots" content="index, follow" />
   <title>Jordan Lander | Portfolio</title>
   <link rel="sitemap" type="application/xml" title="Sitemap" href="/sitemap.xml" />
+  <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
@@ -47,6 +48,17 @@
       <img src="Jordan%20Lander.jpg" alt="Jordan Lander profile" class="profile-pic" />
       <p>I'm a forward-thinking, data-driven education administrator with over 15 years of experience designing inclusive STEAM curricula, leading change initiatives, and empowering teams. I thrive on integrating technology and creativity to foster growth and equity.</p>
     </div>
+  </section>
+
+  <!-- Leadership Highlights Section -->
+  <section id="leadership" class="bg-white my-12 mx-auto max-w-3xl p-8 rounded-lg shadow">
+    <h2 class="text-2xl font-bold text-[#0e2a47] mb-4 border-b-2 border-[#f5a623] inline-block pb-2">Leadership Highlights</h2>
+    <ul class="list-disc pl-5 space-y-2">
+      <li>Redesigned a virtual learning program, improving student engagement and saving over $800K in outplacement costs.</li>
+      <li>Led development of digital tools that streamlined compliance and collaboration for K–12 staff.</li>
+      <li>Implemented data-driven strategies that boosted reading and math performance on standardized assessments.</li>
+      <li>Built partnerships with families and local organizations to support inclusive learning environments.</li>
+    </ul>
   </section>
 
   <!-- Experience Section with Accordion -->


### PR DESCRIPTION
## Summary
- add Tailwind CDN for quick utility classes
- introduce a new "Leadership Highlights" section on the homepage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688d0172cc408331a0792e020fccc1da