### PR TITLE
Fix mobile navigation overlay for X icon

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -43,10 +43,10 @@ body {
   display: block;
   font-size: 1.75rem;
   cursor: pointer;
-  position: absolute;
+  position: fixed;
   right: 1rem;
-  top: 0.5rem;
-  z-index: 200;
+  top: 1rem;
+  z-index: 50;
   color: #0e2a47;
   transition: transform 0.3s ease;
 }
@@ -329,7 +329,7 @@ body {
     left: 0;
     width: 100%;
     background: rgb(17 24 39 / 90%); /* bg-gray-900 bg-opacity-90 */
-    z-index: 150;
+    z-index: 40;
     color: #fff;
     padding: 0;
     margin-bottom: 0;


### PR DESCRIPTION
## Summary
- keep hamburger/X button above the mobile navigation panel
- reduce the mobile menu z-index so it doesn't cover the X icon

## Testing
- `npm run lint:css`


------
https://chatgpt.com/codex/tasks/task_e_688d20d68784833181242bc004fe6b72