### PR TITLE
Add animated orb background to hero

### DIFF
--- a/index.html
+++ b/index.html
@@ -332,6 +332,19 @@
         },
         [
           React.createElement(
+            "div",
+            {
+              key: "orbs",
+              className:
+                "absolute inset-0 pointer-events-none z-0 overflow-hidden",
+            },
+            [
+              React.createElement("span", { key: "o1", className: "orb orb1" }),
+              React.createElement("span", { key: "o2", className: "orb orb2" }),
+              React.createElement("span", { key: "o3", className: "orb orb3" })
+            ]
+          ),
+          React.createElement(
             motion.h1,
 React.createElement(
   motion.h1,

--- a/styles.css
+++ b/styles.css
@@ -416,3 +416,54 @@ body {
   50% { background-position: 100% 50%; }
   100% { background-position: 0% 50%; }
 }
+
+/* Animated orbs for hero background */
+.orb {
+  position: absolute;
+  border-radius: 50%;
+  opacity: 0.35;
+  filter: blur(40px);
+  pointer-events: none;
+}
+
+.orb1 {
+  width: 14rem;
+  height: 14rem;
+  top: 10%;
+  left: 15%;
+  background: radial-gradient(circle at center, #a5b4fc, #6366f1);
+  animation: float1 18s ease-in-out infinite;
+}
+
+.orb2 {
+  width: 12rem;
+  height: 12rem;
+  bottom: 15%;
+  right: 20%;
+  background: radial-gradient(circle at center, #c084fc, #7c3aed);
+  animation: float2 16s ease-in-out infinite;
+}
+
+.orb3 {
+  width: 16rem;
+  height: 16rem;
+  top: 40%;
+  right: 30%;
+  background: radial-gradient(circle at center, #ddd6fe, #8b5cf6);
+  animation: float3 20s ease-in-out infinite;
+}
+
+@keyframes float1 {
+  0%, 100% { transform: translate(0, 0); }
+  50% { transform: translate(30px, -20px); }
+}
+
+@keyframes float2 {
+  0%, 100% { transform: translate(0, 0); }
+  50% { transform: translate(-20px, 25px); }
+}
+
+@keyframes float3 {
+  0%, 100% { transform: translate(0, 0); }
+  50% { transform: translate(-25px, -15px); }
+}


### PR DESCRIPTION
## Summary
- overlay floating orbs behind hero text
- style subtle orb animations in `styles.css`

## Testing
- `npm run lint:css`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688d248f9420833196215fcb13ff2377